### PR TITLE
Fix/improvide validate constructor throws details

### DIFF
--- a/common/src/main/java/dev/endoy/helpers/common/injector/Injector.java
+++ b/common/src/main/java/dev/endoy/helpers/common/injector/Injector.java
@@ -299,11 +299,11 @@ public class Injector
 
     private void validateConstructor( Constructor<?> constructor )
     {
-        if ( !Arrays.stream( constructor.getParameters() ).allMatch( parameter -> this.isInjectable( parameter.getType() ) || parameter.isAnnotationPresent( Value.class ) ) )
+        List<Parameter> nonInjectableParameters = Arrays.stream( constructor.getParameters() )
+            .filter( parameter -> !this.isInjectable( parameter.getType() ) && !parameter.isAnnotationPresent( Value.class ) )
+            .toList();
+        if ( !nonInjectableParameters.isEmpty() )
         {
-            List<Parameter> nonInjectableParameters = Arrays.stream( constructor.getParameters() )
-                .filter( parameter -> !this.isInjectable( parameter.getType() ) && !parameter.isAnnotationPresent( Value.class ) )
-                .toList();
             throw new InvalidInjectionContextException(
                 String.format(
                     "All parameters of an Injectable constructor must be injectable: %s.%n" +

--- a/common/src/main/java/dev/endoy/helpers/common/injector/Injector.java
+++ b/common/src/main/java/dev/endoy/helpers/common/injector/Injector.java
@@ -299,18 +299,21 @@ public class Injector
 
     private void validateConstructor( Constructor<?> constructor )
     {
-        if ( !Arrays.stream( constructor.getParameters() ).allMatch( parameter -> this.isInjectable( parameter.getType() ) || parameter.isAnnotationPresent( Value.class ) ) )
+        List<Parameter> nonInjectableParameters = Arrays.stream( constructor.getParameters() )
+            .filter( parameter -> !this.isInjectable( parameter.getType() ) && !parameter.isAnnotationPresent( Value.class ) )
+            .toList();
+
+        if ( !nonInjectableParameters.isEmpty() )
         {
             throw new InvalidInjectionContextException(
-                """
-                    All parameters of an Injectable constructor must be injectable: %s.
-                    The following parameters could not be injected: %s
-                    """
-                    .formatted(
-                        constructor.getDeclaringClass().getName(),
-                        Arrays.stream( constructor.getParameters() )
-                            .filter( parameter -> !this.isInjectable( parameter.getType() ) && !parameter.isAnnotationPresent( Value.class ) )
-                    )
+                String.format(
+                    "All parameters of an Injectable constructor must be injectable: %s.%n" +
+                        "The following parameters could not be injected: %s",
+                    constructor.getDeclaringClass().getName(),
+                    nonInjectableParameters.stream()
+                        .map( parameter -> String.format( "%s (position %d)", parameter.getType().getName(), Arrays.asList( constructor.getParameters() ).indexOf( parameter ) ) )
+                        .collect( Collectors.joining( ", " ) )
+                )
             );
         }
 

--- a/common/src/main/java/dev/endoy/helpers/common/injector/Injector.java
+++ b/common/src/main/java/dev/endoy/helpers/common/injector/Injector.java
@@ -299,12 +299,11 @@ public class Injector
 
     private void validateConstructor( Constructor<?> constructor )
     {
-        List<Parameter> nonInjectableParameters = Arrays.stream( constructor.getParameters() )
-            .filter( parameter -> !this.isInjectable( parameter.getType() ) && !parameter.isAnnotationPresent( Value.class ) )
-            .toList();
-
-        if ( !nonInjectableParameters.isEmpty() )
+        if ( !Arrays.stream( constructor.getParameters() ).allMatch( parameter -> this.isInjectable( parameter.getType() ) || parameter.isAnnotationPresent( Value.class ) ) )
         {
+            List<Parameter> nonInjectableParameters = Arrays.stream( constructor.getParameters() )
+                .filter( parameter -> !this.isInjectable( parameter.getType() ) && !parameter.isAnnotationPresent( Value.class ) )
+                .toList();
             throw new InvalidInjectionContextException(
                 String.format(
                     "All parameters of an Injectable constructor must be injectable: %s.%n" +
@@ -339,7 +338,7 @@ public class Injector
             }
         }
 
-        visitedDependencies.remove(clazz);
+        visitedDependencies.remove( clazz );
     }
 
     private boolean isInjectable( Class<?> clazz )


### PR DESCRIPTION
From only the class being mentioned
```bash
dev.endoy.helpers.common.injector.InvalidInjectionContextException: All parameters of an Injectable constructor must be injectable: clazz
```

it will now also mention which field's and positions(less important) of said class are the issue,
Instead of only have a global error which doesn't give any clue why said class wasn't being able to be injected